### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/sharkmu/tosk/security/code-scanning/1](https://github.com/sharkmu/tosk/security/code-scanning/1)

To fix the issue, you should add a `permissions` block either at the root of the workflow or inside the affected jobs, specifying the least privileges required. For this workflow, since it only checks out code and runs build/test commands, setting `contents: read` is sufficient. The best fix is to add this block at the workflow root (just after `name: Rust` and before `on:`) so it applies to all jobs unless overridden locally. No changes to existing functionality are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
