### PR TITLE
Folder separation character fix

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,14 @@ use dirs::config_dir;
 use std::fs;
 
 fn main() {
+    let os = std::env::consts::OS;
     let path = config_dir()
         .unwrap()
-        .join("tosk\\");
+        .join(match os{
+            "linux"=>{"tosk/"}
+            "windows"=>{"tosk\\"}
+            _ =>{unimplemented!("handle macos correctly")}
+        });
 
     match fs::read_dir(&path) {
         Ok(_) => handle_args(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,8 @@ fn main() {
         .join(match os{
             "linux"=>{"tosk/"}
             "windows"=>{"tosk\\"}
-            _ =>{unimplemented!("handle macos correctly")}
+            "macos"=>{"tosk/"}
+            _ =>{unimplemented!("handle error or other os correctly")}
         });
 
     match fs::read_dir(&path) {


### PR DESCRIPTION
On unix and unix-like systems folders are separated by /.